### PR TITLE
fix: improve capture disabling logic and update description

### DIFF
--- a/background/index.ts
+++ b/background/index.ts
@@ -123,8 +123,9 @@ function downloadFilter(info: DownloadInfo, settings: Settings): boolean {
   }
 
   if (settings.ctrlDisableCapture && pressToSkip) {
-    return false
+    return !settings.enabled
   }
+
   if (settings.enabled === false) {
     return false
   }

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -156,6 +156,6 @@
     "message": "Disable Capture with Key"
   },
   "ctrl_disable_capture_desc": {
-    "message": "Hold %key% key to temporarily disable download capture"
+    "message": "Hold %key% key to temporarily disable download capture when enabled is on and enabled download capture temporarily when disabled"
   }
 }


### PR DESCRIPTION
This pull request includes changes to improve the behavior of the `downloadFilter` function and update the corresponding user-facing description in the localization file. The changes ensure that the disabling or enabling download capture behavior aligns with the `enabled` setting.

### Functional Changes:
* [`background/index.ts`](diffhunk://#diff-0f6c08bce7e5c0792802ab367da3750e0aa0829b015ad9f6f8c04860454b81adL126-R128): Modified the `downloadFilter` function to return the inverse of the `enabled` setting when `ctrlDisableCapture` is active, ensuring the behavior is consistent with the `enabled` state.

### Localization Updates:
* [`locales/en/messages.json`](diffhunk://#diff-8aa9190a05814c6894dde1e917c699ad0a2951547c963586a884eefb2d918b84L159-R159): Updated the description for the `ctrl_disable_capture_desc` key to clarify the behavior when toggling download capture based on the `enabled` setting.